### PR TITLE
Return page_info with tag media nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ RubyInstagramScraper.get_user_media_nodes( "gopro" )
 RubyInstagramScraper.get_user_media_nodes( "gopro", "1259825963188747360" )
 
 # Get media nodes by tag:
-nodes = RubyInstagramScraper.get_tag_media_nodes( "gopro" )
+data = RubyInstagramScraper.get_tag_media_nodes( "gopro" )
 
-# Get next portion of nodes of same tag by passing last node "id":
-RubyInstagramScraper.get_tag_media_nodes( "gopro", nodes.last["id"] )
+# Get next portion of nodes of same tag by passing the end cursor:
+RubyInstagramScraper.get_tag_media_nodes( "gopro", data['page_info']['end_cursor'] )
 
 # Get media info:
-RubyInstagramScraper.get_media( nodes.first["code"] )
+RubyInstagramScraper.get_media( data["nodes"].first["code"] )
 RubyInstagramScraper.get_media( "BGGnlHDBV3N" )
 ```

--- a/lib/ruby-instagram-scraper.rb
+++ b/lib/ruby-instagram-scraper.rb
@@ -35,9 +35,9 @@ module RubyInstagramScraper
     params = ""
     params = "&max_id=#{ max_id }" if max_id
 
-    data = JSON.parse( open( "#{url}#{params}" ).read )["tag"]["media"]
+    data = JSON.parse( open( "#{url}#{params}" ).read )["graphql"]["hashtag"]["edge_hashtag_to_media"]
 
-    { "nodes" => data["nodes"], "page_info" => data["page_info"] }
+    { "nodes" => data["edges"].map { |e| e['node'] }, "page_info" => data["page_info"] }
   end
 
   def self.get_media ( code )

--- a/lib/ruby-instagram-scraper.rb
+++ b/lib/ruby-instagram-scraper.rb
@@ -35,7 +35,9 @@ module RubyInstagramScraper
     params = ""
     params = "&max_id=#{ max_id }" if max_id
 
-    JSON.parse( open( "#{url}#{params}" ).read )["tag"]["media"]["nodes"]
+    data = JSON.parse( open( "#{url}#{params}" ).read )["tag"]["media"]
+
+    { "nodes" => data["nodes"], "page_info" => data["page_info"] }
   end
 
   def self.get_media ( code )


### PR DESCRIPTION
This is now required to get pages.  The value of `page_info["end_cursor"]` is now used instead of the ID of the last image returned.